### PR TITLE
Review of DM-5002: Make ci_hsc resumable

### DIFF
--- a/python/lsst/ci/hsc/validate.py
+++ b/python/lsst/ci/hsc/validate.py
@@ -3,7 +3,6 @@ __all__ = ["RawValidation", "DetrendValidation", "SfmValidation", "SkymapValidat
            "MergeMeasurementsValidation", "ForcedValidation",]
 
 import os
-import functools
 from lsst.pex.logging import getDefaultLog
 from lsst.daf.persistence import Butler
 
@@ -100,11 +99,6 @@ class Validation(object):
         if self._matchDataset is not None:
             self.log.info("Validating matches output for %s" % dataId)
             self.validateMatches(dataId)
-
-    @classmethod
-    def makeScons(cls, root, *args, **kwargs):
-        self = cls(root)
-        return functools.partial(self.scons, *args, **kwargs)
 
     def scons(self, *args, **kwargs):
         """Strip target,source,env from scons' call"""

--- a/python/lsst/ci/hsc/validate.py
+++ b/python/lsst/ci/hsc/validate.py
@@ -127,7 +127,7 @@ class WarpValidation(Validation):
     _datasets = ["deepCoadd_tempExp", "deep_makeCoaddTempExp_config", "deep_makeCoaddTempExp_metadata"]
 
 class CoaddValidation(Validation):
-    _datasets = ["deepCoadd", "deep_assembleCoadd_config", "deep_assembleCoadd_metadata"]
+    _datasets = ["deepCoadd", "deep_safeClipAssembleCoadd_config", "deep_safeClipAssembleCoadd_metadata"]
 
 class DetectionValidation(Validation):
     _datasets = ["deepCoadd_det_schema", "detectCoaddSources_config", "detectCoaddSources_metadata"]


### PR DESCRIPTION
In the case where ci_hsc fails or is aborted, scons should be
resumable. Make this so by changing how function signatures are
created for functools.partial objects by wrapping them in a custom
child class of SCons.Action.FunctionAction.