### PR TITLE
DM-5135: "Make ci_hsc buildable by Jenkins"

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -226,5 +226,8 @@ def forcedPhot(filterName):
 
 forced = [forcedPhot(ff) for ff in filterList]
 
+# Add a no-op install target to keep Jenkins happy.
+env.Alias("install", "SConstruct")
+
 env.Alias("all", forced)
 Default(forced)

--- a/ups/ci_hsc.table
+++ b/ups/ci_hsc.table
@@ -1,3 +1,8 @@
 setupRequired(pipe_tasks)
 setupRequired(obs_subaru)
+# Explicitly set up the local version of an SDSS astrometry net data
+#  directory for use by obs_subaru.  The *version* name is important
+#  as obs_subaru uses it to determine which filters to use for color terms.
+envSet(SETUP_ASTROMETRY_NET_DATA, astrometry_net_data sdss-dr9-fink-v5b)
+envSet(ASTROMETRY_NET_DATA_DIR, ${PRODUCT_DIR}/sdss-dr9-fink-v5b)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
Builds under Jenkins.
Fails successfully on a known broken pipe_tasks.

 * Adds no-op 'install' to cons.
 * Sets up fake astrometry_net_data to get right color terms used.