### PR TITLE
DM-5372: Fix obs_* packages and ci tests broken by DM-4683

### DIFF
--- a/python/lsst/ci/hsc/validate.py
+++ b/python/lsst/ci/hsc/validate.py
@@ -75,7 +75,9 @@ class Validation(object):
         self.assertTrue("%s exists" % dataset, self.butler.datasetExists(datasetType=dataset, dataId=dataId))
         # Just warn if we can't load a PropertySet or PropertyList; there's a known issue
         # (DM-4927) that prevents these from being loaded on Linux, with no imminent resolution.
-        mappable = self.butler.mapper.datasets.get(dataset, None)
+        mappers = self.butler.repository.mappers()
+        mapper = mappers[0]  # Should only be one right now, but someday there can be several.
+        mappable = mapper.datasets.get(dataset, None)
         if mappable is not None and mappable.persistable.startswith("Property"):
             try:
                 data = self.butler.get(dataset, dataId)


### PR DESCRIPTION
Use butler.repository.mappers() to get the mapper in workaround to DM-4927

Instead of butler.mapper get the mapper from butler.repository.mappers()
This is due to the change in Butler (daf_persistence) DM-4683.