### PR TITLE
ci_hsc DM-9885: Rename deepCoadd_srcMatch as deepCoadd_measMatch

### DIFF
--- a/python/lsst/ci/hsc/validate.py
+++ b/python/lsst/ci/hsc/validate.py
@@ -228,8 +228,8 @@ class MergeDetectionsValidation(Validation):
 class MeasureValidation(Validation):
     _datasets = ["measureCoaddSources_config", "measureCoaddSources_metadata", "deepCoadd_meas_schema"]
     _sourceDataset = "deepCoadd_meas"
-    _matchDataset = "deepCoadd_srcMatch"
-    _matchFullDataset = "deepCoadd_srcMatchFull"
+    _matchDataset = "deepCoadd_measMatch"
+    _matchFullDataset = "deepCoadd_measMatchFull"
 
     def validateSources(self, dataId):
         catalog = Validation.validateSources(self, dataId)


### PR DESCRIPTION
The naming appears to be an error during the port of functionality
from HSC. Renamed in order to make clearer the relationship with the
deepCoadd_meas catalog.

Also renamed the related deepCoadd_srcMatchFull as
deepCoadd_measMatchFull.