### PR TITLE
DM-14842: Fix deprecation warnings from PropertyList/Set.get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ config.log
 DATA
 *.pyc
 bin/
+.cache
+.pytest_cache
+pytest_session.txt
+.coverage

--- a/python/lsst/ci/hsc/validate.py
+++ b/python/lsst/ci/hsc/validate.py
@@ -61,13 +61,13 @@ def main():
 
 
 class Validation(object):
-    _datasets = [] # List of datasets to check we can read
-    _files = [] # List of datasets to check that file exists
-    _sourceDataset = None # Dataset name of source catalog
-    _minSources = 100 # Minimum number of sources
-    _matchDataset = None # Dataset name of matches
+    _datasets = []  # List of datasets to check we can read
+    _files = []  # List of datasets to check that file exists
+    _sourceDataset = None  # Dataset name of source catalog
+    _minSources = 100  # Minimum number of sources
+    _matchDataset = None  # Dataset name of matches
     _matchFullDataset = None  # Dataset name of denormalized matches
-    _minMatches = 10 # Minimum number of matches
+    _minMatches = 10  # Minimum number of matches
     _butler = {}
 
     def __init__(self, root, log=None):
@@ -107,7 +107,6 @@ class Validation(object):
     def assertLessEqual(self, description, num1, num2):
         self.assertTrue(description + " (%s <= %s)" % (num1, num2), num1 <= num2)
 
-
     def checkApertureCorrections(self, catalog):
         """Utility function for derived classes that want to verify that aperture corrections were applied
         """
@@ -117,7 +116,6 @@ class Validation(object):
                             (("%s_apCorrSigma" % alg) in catalog.schema) and
                             (("%s_flag_apCorr" % alg) in catalog.schema))
 
-
     def validateDataset(self, dataId, dataset):
         self.assertTrue("%s exists" % dataset, self.butler.datasetExists(datasetType=dataset, dataId=dataId))
         # Just warn if we can't load a PropertySet or PropertyList; there's a known issue
@@ -125,7 +123,7 @@ class Validation(object):
         try:
             data = self.butler.get(dataset, dataId)
             self.assertTrue("%s readable (%s)" % (dataset, data.__class__), data is not None)
-        except:
+        except Exception:
             if dataset.endswith("metadata"):
                 self.log.warn("Unable to load '%s'; this is likely DM-4927." % dataset)
                 return
@@ -205,7 +203,7 @@ class SfmValidation(Validation):
     def validateSources(self, dataId):
         catalog = Validation.validateSources(self, dataId)
         self.checkApertureCorrections(catalog)
-        # Check that at least 95% of the stars we used to model the PSF end up classified as stars. We 
+        # Check that at least 95% of the stars we used to model the PSF end up classified as stars. We
         # certainly need much more purity than that to build good PSF models, but
         # this should verify that aperture correction and extendendess are running and configured reasonably
         # (but it may not be sensitive enough to detect subtle bugs).

--- a/python/lsst/ci/hsc/validate.py
+++ b/python/lsst/ci/hsc/validate.py
@@ -262,7 +262,7 @@ class DetectionValidation(Validation):
         Validation.run(self, dataId, **kwargs)
 
         md = self.butler.get("deepCoadd_calexp_md", dataId)
-        varScale = md.get("variance_scale")
+        varScale = md.getScalar("variance_scale")
         self.assertGreater("variance_scale is positive", varScale, 0.0)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 110
+ignore = E133, E226, E228, N802, N803, N806
+exclude =
+    __init__.py,
+    forcedPhotCcdConfig.py,
+    skymap.py,
+    ps1_pv3_3pi_20170110/config.py
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 N802 N803 N806

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,0 +1,4 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+
+scripts.BasicSConscript.tests(pyList=[])

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,22 @@
+import unittest
+
+import lsst.utils.tests
+import lsst.ci.hsc.validate
+
+
+class ImportTest(unittest.TestCase):
+    def testImport(self):
+        self.assertTrue(hasattr(lsst.ci.hsc.validate, "RawValidation"))
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
Use `getScalar` or `getArray` instead of deprecated `get`
on `PropertySet` and `PropertyList` instances.