### PR TITLE
DM-15727: Disable CModel in forcedPhotCcd

### DIFF
--- a/forcedPhotCcdConfig.py
+++ b/forcedPhotCcdConfig.py
@@ -1,10 +1,3 @@
 # We haven't processed all the patches that overlap some of our CCDs
 # to save some time.
 config.references.skipMissing = True
-
-# CModel doesn't yet implement forced photometry when WCSs differ,
-# so we disable it here (and reset the classification parameters
-# to use GaussianFlux).
-config.measurement.plugins.names.discard("modelfit_CModel")
-config.measurement.slots.modelFlux = "base_GaussianFlux"
-config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.925


### PR DESCRIPTION
The activation of CModel in forcedPhotCcd has been removed in obs_subaru
because CModel doesn't work in forcedPhotCcd. That means this snippet
undoing the activation is no longer necessary, and we want to test the
most vanilla configuration possible.