### PR TITLE
DM-17300: Put brightObjectMasks in rerun, and do it after defining SkyMap.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -230,13 +230,6 @@ refcat = env.Command(refcatPath, mapper,
                      ["rm -f " + refcatPath,  # Delete any existing, perhaps leftover from previous
                       "ln -s %s %s" % (os.path.join(root, refcatName), refcatPath)])
 
-brightObjSource = os.path.join(root, "brightObjectMasks")
-brightObjTarget = os.path.join(REPO, "deepCoadd", "BrightObjectMasks")
-brightObj = env.Command(brightObjTarget, mapper,
-                        ["rm -f " + brightObjTarget,  # Delete any existing
-                         "mkdir -p " + os.path.dirname(brightObjTarget),
-                         "ln -s %s %s" % (brightObjSource, brightObjTarget)])
-
 # Add transmission curves to the repository.
 transmissionCurvesTarget = os.path.join(REPO, "transmission")
 transmissionCurves = env.Command(transmissionCurvesTarget, calib,
@@ -248,6 +241,15 @@ transmissionCurves = env.Command(transmissionCurvesTarget, calib,
 skymap = command("skymap", mapper,
                  [getExecutable("pipe_tasks", "makeSkyMap.py") + " " + PROC + " -C skymap.py " + STDARGS,
                   validate(SkymapValidation, DATADIR, gen3id=dict(skymap="ci_hsc"))])
+
+# Add brightObjectMasks to the *rerun* dir, because their data IDs involve
+# the tracts and patches defined by the skymap.
+brightObjSource = os.path.join(root, "brightObjectMasks")
+brightObjTarget = os.path.join(DATADIR, "deepCoadd", "BrightObjectMasks")
+brightObj = env.Command(brightObjTarget, [mapper, skymap],
+                        ["rm -f " + brightObjTarget,  # Delete any existing
+                         "mkdir -p " + os.path.dirname(brightObjTarget),
+                         "ln -s %s %s" % (brightObjSource, brightObjTarget)])
 
 # Single frame measurement
 # preSfm step is a work-around for a race on schema/config/versions

--- a/tests/test_gen2convert.py
+++ b/tests/test_gen2convert.py
@@ -29,6 +29,7 @@ from lsst.utils import getPackageDir
 from lsst.daf.butler import Butler, DataId, DatasetOriginInfoDef
 from lsst.daf.persistence import Butler as Butler2
 from lsst.obs.subaru.gen3.hsc import HyperSuprimeCam
+from lsst.pipe.tasks.objectMasks import ObjectMaskCatalog
 
 
 REPO_ROOT = os.path.join(getPackageDir("ci_hsc"), "DATA")
@@ -159,6 +160,14 @@ class Gen2ConvertTestCase(lsst.utils.tests.TestCase):
             defects = butler.get(refsByName["defects"])
             self.assertIsInstance(defects, BaseCatalog)
             self.assertEqual(defects.schema.getNames(), {"x0", "y0", "width", "height"})
+
+    def testBrightObjectMasks(self):
+        """Test that bright object masks are included in the Gen3 repo.
+        """
+        regions = self.butler.get("brightObjectMask", skymap='ci_hsc', tract=0, patch=69,
+                                  abstract_filter='r')
+        self.assertIsInstance(regions, ObjectMaskCatalog)
+        self.assertGreater(len(regions), 0)
 
 
 def setup_module(module):


### PR DESCRIPTION
It doesn't make sense to put a dataset that's identified by (tract, patch) in a repo (like the root) that doesn't have a skymap to define the tracts and patches.

(Gen2 butler let us get away with this, but Gen3 does not.)